### PR TITLE
feat: support starting index in CultivationPropagationModel prediction

### DIFF
--- a/dhl_sdk/_utils.py
+++ b/dhl_sdk/_utils.py
@@ -49,14 +49,14 @@ class Instance(BaseModel):
     timestamps: Optional[list[int]] = Field(default=None, alias="timestamps")
     sample_id: Optional[list[str]] = Field(default=None, alias="sampleId")
     steps: Optional[list[int]] = Field(default=None, alias="steps")
-    values: Union[list[float], list[list[float]]]
+    values: Union[list[Optional[float]], list[list[Optional[float]]]]
 
-    high_values: Optional[Union[list[float], list[list[float]]]] = Field(
-        default=None, alias="highValues"
-    )
-    low_values: Optional[Union[list[float], list[list[float]]]] = Field(
-        default=None, alias="lowValues"
-    )
+    high_values: Optional[
+        Union[list[Optional[float]], list[list[Optional[float]]]]
+    ] = Field(default=None, alias="highValues")
+    low_values: Optional[
+        Union[list[Optional[float]], list[list[Optional[float]]]]
+    ] = Field(default=None, alias="lowValues")
 
     @model_validator(mode="after")
     def generate_sample_ids(self):

--- a/dhl_sdk/entities.py
+++ b/dhl_sdk/entities.py
@@ -233,11 +233,14 @@ class PredictionConfig(BaseModel):
         expected to fall, with a specified level of certainty, i.e, setting it to 80%
         corresponds to capturing the range between the 10th and 90th percentiles
         of the model's output. Must be a value between 1 and 99, by default 80
+    starting_index: int, optional
+        The index of the timestamp after which the prediction will commence
     """
 
     model_config = ConfigDict(protected_namespaces=())
 
     model_confidence: float = Field(default=80.0, ge=1.0, le=99.0)
+    starting_index: int = Field(default=0, ge=0)
 
 
 class SpectraModel(Model):
@@ -417,7 +420,8 @@ class CultivationPropagationModel(CultivationModel):
             )
 
         prediction_config = PredictionRequestConfig.new(
-            model_confidence=config.model_confidence
+            model_confidence=config.model_confidence,
+            starting_index=config.starting_index,
         )
 
         data_processing_strategy = CultivationPropagationPreprocessor(


### PR DESCRIPTION
## Overview

To enable the prediction using the startingIndex functionality, I needed to add the steps to the prediction request formatted in the CultivationPropagationPreprocessor, the steps are simply generated from the timestamps

the validations stay the same, ultimately the users only have to specify the starting_index in the PredictionConfig that is an input to the `model.predict` method:

```python
key = APIKeyAuthentication(API_KEY)
client = DataHowLabClient(
    auth_key=key, base_url="https://dev.datahowlab.ch/", verify_ssl=False
)

projects = client.get_projects(name="testytest")
project = next(projects)

models = project.get_models(name="Model #1", model_type="propagation")
model = next(models)

# prepare the inputs, timestamps and so on, in the same way as before

# starting index will place the defined starting values for the X variables at the right timestamp
response = model.predict(
    timestamps=timestamps, inputs=inputs, config=PredictionConfig(starting_index=9)
)
```

in the returned dict from the predict function, the timestamps will be listed and where no prediction happened `null` will appear, while after the defined starting_index the predicted X variables will start to appear:
```json
{
  "VCD": {
          "values": [
              null,
              null,
              null,
              null,
              null,
              null,
              null,
              null,
              null,
              2.879112482070923,
              2.4005997326441006,
              1.9871806082628867,
              1.681387192593827,
              1.4050851085900333,
              1.194962512785351
          ],
          "upperBound": [
              null,
              null,
              null,
              null,
              null,
              null,
              null,
              null,
              null,
              2.879112482070923,
              2.493029799377218,
              2.120593437479122,
              1.8562090157041424,
              1.6714378289059812,
              1.4606777007638796
          ],
          "lowerBound": [
              null,
              null,
              null,
              null,
              null,
              null,
              null,
              null,
              null,
              2.879112482070923,
              2.3057709871156935,
              1.8248368874560694,
              1.4678880165432826,
              1.1231916636850299,
              0.8331586939798415
          ]
      }
}
``` 

## Main Changes

**_input_processing.CultivationPropagationPreprocessor**
- validate: I had to introduce in the validation for cultivation propagation models a check that the starting_index is within the length of the defined timestamps
- format: here is the arguably largest change: include a step for each timestamp (its just needed to align the initial X variables with the correct timestamp) and differentiate between non-X variables and X variables to make that alignment using the `self.prediction_config.starting_index`

**_utils.Instance**
- I had to enable the presence of nulls in the parsed instance data (specifically inside values) to allow all the resulting X variable outputs to be null before the starting index (otherwise we can also find a way to truncate this output but this is a first proposition which I find quite elegant)

**entities.CultivationPropagationModel**
- I added the `starting_index` coming from the `PredictionConfig` to the `PredictionRequestConfig.new` constructor s.t. everything is properly hooked up on the frontend of the SDK
